### PR TITLE
Expose numeric exchange repr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["ticker", "zerodha", "web-sockets", "trading", "real-time"]
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_repr = "0.1"
 tokio = { version = "1.28.2", features = ["full"] }
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 futures-util = { version = "0.3.28", features = ["sink"] }

--- a/src/models/exchange.rs
+++ b/src/models/exchange.rs
@@ -1,18 +1,21 @@
-#[derive(Debug, Clone, Default, PartialEq)]
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
 ///
 /// Exchange options
 ///
 pub enum Exchange {
   #[default]
-  NSE,
-  NFO,
-  CDS,
-  BSE,
-  BFO,
-  BCD,
-  MCX,
-  MCXSX,
-  INDICES,
+  NSE = 1,
+  NFO = 2,
+  CDS = 3,
+  BSE = 4,
+  BFO = 5,
+  BCD = 6,
+  MCX = 7,
+  MCXSX = 8,
+  INDICES = 9,
 }
 
 impl Exchange {


### PR DESCRIPTION
## Summary
- add serde_repr dependency
- define `Exchange` enum as `repr(u8)` and derive Serialize/Deserialize via serde_repr

## Testing
- `cargo check`
- `cargo test --workspace` *(fails: NotPresent)*

------
https://chatgpt.com/codex/tasks/task_e_68524bbfc15c83338121f5e1e40e6349