### PR TITLE
Add flake.nix for fenix toolchain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Development environment for kiteticker-async";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, fenix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        toolchain = fenix.packages.${system}.stable.toolchain;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            toolchain
+            pkgs.rust-analyzer
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- provide a flake to create a dev shell

## Testing
- `cargo test --workspace --quiet` *(fails: couldn't read kiteconnect-mocks/postback.json)*

------
https://chatgpt.com/codex/tasks/task_e_685256369194833386b9c97fe100abf2